### PR TITLE
INT-6206 - Handling instances where bundle ID isn't present

### DIFF
--- a/src/steps/app/converter.ts
+++ b/src/steps/app/converter.ts
@@ -6,8 +6,30 @@ import {
 import { Entities } from '../constants';
 import { App } from '../../types';
 
-export function getAppKey(bundleId: string): string {
-  return `kandji_app:${bundleId}`;
+// We have seen issues switching to using the bundle ID for
+// key generation where the value comes back as 'No value'
+// or an empty string.  In this instance, we need to fall
+// back to the app name or app ID.  Using the app ID for now
+// since it is a guaranteed value and is guaranteed to be
+// unique.
+export function getKeyId(app: App): string {
+  if (app.bundle_id === 'No value' || app.bundle_id === '') {
+    return app.app_id;
+  } else {
+    return app.bundle_id;
+  }
+}
+
+export function getAppKey(app: App): string {
+  return `kandji_app:${getKeyId(app)}`;
+}
+
+// Manually construct the key for this relationship so we can use the appId
+// to guarantee uniqueness.  Instances where multiple versions of the same
+// app being installed will be handled by having multiple relationships to
+// the same kandji_app.
+export function getDeviceHasAppKey(deviceKey: string, appId: string): string {
+  return `${deviceKey}|has|kandji_app:${appId}`;
 }
 
 export function createAppEntity(app: App): Entity {
@@ -15,7 +37,7 @@ export function createAppEntity(app: App): Entity {
     entityData: {
       source: app,
       assign: {
-        _key: getAppKey(app.bundle_id),
+        _key: getAppKey(app),
         _type: Entities.APP._type,
         _class: Entities.APP._class,
         name: app.app_name,


### PR DESCRIPTION
# Description

Thank you for contributing to a JupiterOne integration!

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Summary

After running against a larger dataset, we found issues with the step that ingests application data.  Not all applications are guaranteed to have a valid bundle ID, so we need to add an option to handle the case where it comes back as 'No value' or an empty string.

Additionally, I added in a small change to handle the case where a device has multiple versions of the same application installed.  In this instance, we'll create multiple relationships to that application entity to preserve information for each version installed.

## Type of change

Please leave any irrelevant options unchecked.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
